### PR TITLE
Chang class name and remove did not use code

### DIFF
--- a/Sources/Spritesheet.Sample.macOS/Game.cs
+++ b/Sources/Spritesheet.Sample.macOS/Game.cs
@@ -13,7 +13,7 @@
 
 		private SpriteBatch spriteBatch;
 
-		private Spritesheet sheet;
+		private SpriteSheet sheet;
 
 		private Animation[] animations;
 
@@ -49,7 +49,7 @@
 
 			this.font.LoadContent(this.GraphicsDevice);
 
-			this.sheet = new Spritesheet(LoadTexture("characters"))
+			this.sheet = new SpriteSheet(LoadTexture("characters"))
 										.WithGrid((32, 32));
 
 			this.animations = new[]

--- a/Sources/Spritesheet/AnimationDefinition.cs
+++ b/Sources/Spritesheet/AnimationDefinition.cs
@@ -1,15 +1,10 @@
-﻿namespace Spritesheet
-{
-	using System.Linq;
+﻿namespace Spritesheet {
 
-	public class AnimationDefinition
-	{
-		public AnimationDefinition(string name, Frame[] frames)
-		{
-			this.Name = name;
-		}
+    public class AnimationDefinition {
+        public AnimationDefinition(string name, Frame[] frames) {
+            Name = name;
+        }
+        public string Name { get; }
 
-		public string Name { get; }
-
-	}
+    }
 }

--- a/Sources/Spritesheet/Base/Repeat.cs
+++ b/Sources/Spritesheet/Base/Repeat.cs
@@ -1,52 +1,39 @@
-﻿namespace Spritesheet
-{
-	using System;
+﻿namespace Spritesheet {
+    using System;
 
-	public static class Repeat
-	{
-		/// <summary>
-		/// A repeat mode for any kind of animation.
-		/// </summary>
-		public enum Mode
-		{
-			Once,
-			OnceWithReverse,
-			Loop,
-			LoopWithReverse,
-			Reverse,
-		}
+    public static class Repeat {
+        /// <summary>
+        /// A repeat mode for any kind of animation.
+        /// </summary>
+        public enum Mode {
+            Once,
+            OnceWithReverse,
+            Loop,
+            LoopWithReverse,
+            Reverse,
+        }
+        /// <summary>
+        /// Calculate the current value for a time between zero and one, and a curve mode.
+        /// </summary>
+        public static double Calculate(Mode mode, double time) {
+            if (mode == Mode.Once)
+                time = Math.Min(Math.Max(time, 0.0f), 1.0f);
+            else if (mode == Mode.Reverse)
+                time = 1.0f - Math.Min(Math.Max(time, 0.0f), 1.0f);
+            else if (mode == Mode.Loop)
+                time %= 1.0f;
+            else if (mode == Mode.LoopWithReverse)
+                time %= 2.0f;
+            if ((mode == Mode.OnceWithReverse || mode == Mode.LoopWithReverse) && time > 1.0f) {
+                time = 2.0f - time;
+            }
+            return time;
+        }
 
-		/// <summary>
-		/// Calculate the current value for a time between zero and one, and a curve mode.
-		/// </summary>
-		/// <param name="mode">Curve mode.</param>
-		/// <param name="time">Current time (1.0f represents the one way total duration).</param>
-		public static double Calculate(Mode mode, double time)
-		{
-			if (mode == Mode.Once)
-				time = Math.Min(Math.Max(time, 0.0f), 1.0f);
-			else if (mode == Mode.Reverse)
-				time = 1.0f - Math.Min(Math.Max(time, 0.0f), 1.0f);
-			else if (mode == Mode.Loop)
-				time %= 1.0f;
-			else if (mode == Mode.LoopWithReverse)
-				time %= 2.0f;
-
-			if ((mode == Mode.OnceWithReverse || mode == Mode.LoopWithReverse) && time > 1.0f)
-			{
-				time = 2.0f - time;
-			}
-
-			return time;
-		}
-
-		/// <summary>
-		/// Indicates whether the animation is finished.
-		/// </summary>
-		/// <param name="mode"></param>
-		/// <param name="time"></param>
-		/// <returns></returns>
-		public static bool IsFinished(Mode mode, double time) => (((mode == Repeat.Mode.Once || mode == Repeat.Mode.Reverse) && time >= 1.0f) ||
-																(mode == Repeat.Mode.OnceWithReverse && time >= 2.0f));
-	}
+        /// <summary>
+        /// Indicates whether the animation is finished.
+        /// </summary>
+        public static bool IsFinished(Mode mode, double time) => (((mode == Repeat.Mode.Once || mode == Repeat.Mode.Reverse) && time >= 1.0f) ||
+                                                                (mode == Repeat.Mode.OnceWithReverse && time >= 2.0f));
+    }
 }

--- a/Sources/Spritesheet/Frame.cs
+++ b/Sources/Spritesheet/Frame.cs
@@ -1,56 +1,48 @@
-﻿namespace Spritesheet
-{
-	using Microsoft.Xna.Framework;
-	using Microsoft.Xna.Framework.Graphics;
+﻿namespace Spritesheet {
+    using Microsoft.Xna.Framework;
+    using Microsoft.Xna.Framework.Graphics;
 
-	public class Frame
-	{
-		public Frame(Texture2D texture, Rectangle area, Point origin, double duration, SpriteEffects effects)
-		{
-			this.Texture = texture;
-			this.Area = area;
-			this.Origin = origin;
-			this.Duration = duration;
-			this.Effects = effects;
-		}
+    public class Frame {
+        public Frame(Texture2D texture, Rectangle area, Point origin, double duration, SpriteEffects effects) {
+            Texture = texture;
+            Area = area;
+            Origin = origin;
+            Duration = duration;
+            Effects = effects;
+        }
 
-		public Texture2D Texture { get; }
+        public Texture2D Texture { get; }
 
-		public Rectangle Area { get; }
+        public Rectangle Area { get; }
 
-		public Point Origin { get; }
+        public Point Origin { get; }
 
-		public double Duration { get; }
+        public double Duration { get; }
 
-		public SpriteEffects Effects { get; }
+        public SpriteEffects Effects { get; }
 
-		#region Cloning
+        #region Cloning
 
-		public Frame FlipX()
-		{
-			return new Frame(this.Texture, this.Area, this.Origin, this.Duration, SpriteEffects.FlipHorizontally);
-		}
+        public Frame FlipX() {
+            return new Frame(Texture, Area, Origin, Duration, SpriteEffects.FlipHorizontally);
+        }
 
-		public Frame FlipY()
-		{
-			return new Frame(this.Texture, this.Area, this.Origin, this.Duration, SpriteEffects.FlipVertically);
-		}
+        public Frame FlipY() {
+            return new Frame(Texture, Area, Origin, Duration, SpriteEffects.FlipVertically);
+        }
 
-		public Frame WithDuration(double duration)
-		{
-			return new Frame(this.Texture, this.Area, this.Origin, duration, this.Effects);
-		}
+        public Frame WithDuration(double duration) {
+            return new Frame(Texture, Area, Origin, duration, Effects);
+        }
 
-		public Frame WithOrigin(int x, int y)
-		{
-			return new Frame(this.Texture, this.Area, new Point(x, y), this.Duration, this.Effects);
-		}
+        public Frame WithOrigin(int x, int y) {
+            return new Frame(Texture, Area, new Point(x, y), Duration, Effects);
+        }
 
-		public Frame WithArea(Rectangle area)
-		{
-			return new Frame(this.Texture, area, this.Origin, this.Duration, this.Effects);
-		}
+        public Frame WithArea(Rectangle area) {
+            return new Frame(Texture, area, Origin, Duration, Effects);
+        }
 
-		#endregion
-	}
+        #endregion
+    }
 }

--- a/Sources/Spritesheet/Spritesheet.cs
+++ b/Sources/Spritesheet/Spritesheet.cs
@@ -1,93 +1,81 @@
-﻿namespace Spritesheet
-{
-	using Microsoft.Xna.Framework;
-	using Microsoft.Xna.Framework.Graphics;
-	using System.Linq;
+﻿namespace Spritesheet {
+    using Microsoft.Xna.Framework;
+    using Microsoft.Xna.Framework.Graphics;
+    using System.Linq;
 
-	public class Spritesheet
-	{
-		public Spritesheet(Texture2D texture) : this(texture,null,null,null) {}
+    public class SpriteSheet {
+        public SpriteSheet(Texture2D texture) : this(texture, null, null, null) { }
 
-		private Spritesheet(Texture2D texture, Point? cellSize = null, Point? cellOffset = null, Point? cellOrigin = null, double frameDuration = 200.0f, SpriteEffects frameEffects = SpriteEffects.None)
-		{
-			this.Texture = texture;
-			this.CellSize = cellSize ?? new Point(32,32);
-			this.CellOffset = cellOffset ?? new Point(0,0);
-			this.CellOrigin = cellOrigin ?? this.CellSize / new Point(2,2);
-			this.FrameDefaultDuration = frameDuration;
-			this.FrameDefaultEffects = frameEffects;
-		}
+        private SpriteSheet(Texture2D texture, Point? cellSize = null, Point? cellOffset = null, Point? cellOrigin = null, double frameDuration = 200.0f, SpriteEffects frameEffects = SpriteEffects.None) {
+            Texture = texture;
+            CellSize = cellSize ?? new Point(32, 32);
+            CellOffset = cellOffset ?? new Point(0, 0);
+            CellOrigin = cellOrigin ?? CellSize / new Point(2, 2);
+            FrameDefaultDuration = frameDuration;
+            FrameDefaultEffects = frameEffects;
+        }
 
-		#region Properties
+        #region Properties
 
-		public Texture2D Texture { get; }
+        public Texture2D Texture { get; }
 
-		public Point CellSize { get; }
+        public Point CellSize { get; }
 
-		public Point CellOffset { get; }
+        public Point CellOffset { get; }
 
-		public Point CellOrigin { get; }
+        public Point CellOrigin { get; }
 
-		public double FrameDefaultDuration { get; }
+        public double FrameDefaultDuration { get; }
 
-		public SpriteEffects FrameDefaultEffects { get; } 
+        public SpriteEffects FrameDefaultEffects { get; }
 
-		#endregion
+        #endregion
 
-		#region Grid
+        #region Grid
 
-		public Spritesheet WithGrid((int w, int h) cell, (int x, int y) offset, (int x, int y) cellOrigin)
-		{
-			return new Spritesheet(this.Texture, new Point(cell.w, cell.h), new Point(offset.x, offset.y), new Point(cellOrigin.x, cellOrigin.y));
-		}
+        public SpriteSheet WithGrid((int w, int h) cell, (int x, int y) offset, (int x, int y) cellOrigin) {
+            return new SpriteSheet(this.Texture, new Point(cell.w, cell.h), new Point(offset.x, offset.y), new Point(cellOrigin.x, cellOrigin.y));
+        }
 
-		public Spritesheet WithGrid((int w, int h) cell, (int x, int y) offset)
-		{
-			return this.WithGrid(cell, offset, (cell.w / 2, cell.h / 2));
-		}
+        public SpriteSheet WithGrid((int w, int h) cell, (int x, int y) offset) {
+            return this.WithGrid(cell, offset, (cell.w / 2, cell.h / 2));
+        }
 
-		public Spritesheet WithGrid((int w, int h) cell)
-		{
-			return this.WithGrid(cell, (0,0), (cell.w / 2, cell.h / 2));
-		}
+        public SpriteSheet WithGrid((int w, int h) cell) {
+            return this.WithGrid(cell, (0, 0), (cell.w / 2, cell.h / 2));
+        }
 
-		#endregion
+        #endregion
 
-		#region Frame default settings
+        #region Frame default settings
 
-		public Spritesheet WithFrameDuration(double durationInMs)
-		{
-			return new Spritesheet(this.Texture, this.CellSize, this.CellOffset, this.CellOrigin, durationInMs, this.FrameDefaultEffects);
-		}
+        public SpriteSheet WithFrameDuration(double durationInMs) {
+            return new SpriteSheet(this.Texture, this.CellSize, this.CellOffset, this.CellOrigin, durationInMs, this.FrameDefaultEffects);
+        }
 
-		public Spritesheet WithFrameEffect(SpriteEffects effects)
-		{
-			return new Spritesheet(this.Texture, this.CellSize, this.CellOffset, this.CellOrigin, this.FrameDefaultDuration, effects);
-		}
+        public SpriteSheet WithFrameEffect(SpriteEffects effects) {
+            return new SpriteSheet(this.Texture, this.CellSize, this.CellOffset, this.CellOrigin, this.FrameDefaultDuration, effects);
+        }
 
-		#endregion
+        #endregion
 
-		public Frame CreateFrame(int x, int y, double duration = 0.0, SpriteEffects effects = SpriteEffects.None)
-		{
-			x = x * this.CellSize.X + this.CellOffset.X;
-			y = y * this.CellSize.Y + this.CellOffset.Y;
-			var area = new Rectangle(x, y, this.CellSize.X, this.CellSize.Y);
-			return new Frame(this.Texture, area, this.CellOrigin, duration, effects);
-		}
+        public Frame CreateFrame(int x, int y, double duration = 0.0, SpriteEffects effects = SpriteEffects.None) {
+            x = x * CellSize.X + CellOffset.X;
+            y = y * CellSize.Y + CellOffset.Y;
+            var area = new Rectangle(x, y, CellSize.X, CellSize.Y);
+            return new Frame(Texture, area, CellOrigin, duration, effects);
+        }
 
-		public Animation CreateAnimation(params (int x, int y, double duration, SpriteEffects effects)[] frames)
-		{
-			return new Animation(frames.Select(f => this.CreateFrame(f.x, f.y, f.duration, f.effects)).ToArray());
-		}
+        public Animation CreateAnimation(params (int x, int y, double duration, SpriteEffects effects)[] frames) {
+            return new Animation(frames.Select(f => CreateFrame(f.x, f.y, f.duration, f.effects)).ToArray());
+        }
 
-		public Animation CreateAnimation(params (int x, int y, double duration)[] frames)
-		{
-			return this.CreateAnimation(frames.Select(x => (x.x, x.y, x.duration, this.FrameDefaultEffects)).ToArray());
-		}
+        public Animation CreateAnimation(params (int x, int y, double duration)[] frames) {
+            return this.CreateAnimation(frames.Select(x => (x.x, x.y, x.duration, FrameDefaultEffects)).ToArray());
+        }
 
-		public Animation CreateAnimation(params (int x, int y)[] frames)
-		{
-			return this.CreateAnimation(frames.Select(x => (x.x, x.y, this.FrameDefaultDuration, this.FrameDefaultEffects)).ToArray());
-		}
-	}
+        public Animation CreateAnimation(params (int x, int y)[] frames) {
+            return this.CreateAnimation(frames.Select(x => (x.x, x.y, FrameDefaultDuration, FrameDefaultEffects)).ToArray());
+        }
+    }
 }

--- a/Sources/Spritesheet/Spritesheet.csproj
+++ b/Sources/Spritesheet/Spritesheet.csproj
@@ -31,24 +31,21 @@
     <Compile Include="Animation.cs" />
     <Compile Include="Base\Repeat.cs" />
     <Compile Include="Extensions\SpriteBatchExtensions.cs" />
-    <Compile Include="Spritesheet.cs" />
+    <Compile Include="SpriteSheet.cs" />
     <Compile Include="AnimationDefinition.cs" />
     <Compile Include="Frame.cs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="MonoGame.Framework">
-      <HintPath>..\packages\MonoGame.Framework.Portable.3.6.0.1625\lib\portable-net45+win8+wpa81\MonoGame.Framework.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\MonoGame\v3.0\Assemblies\Windows\MonoGame.Framework.dll</HintPath>
     </Reference>
-    <Reference Include="System.ValueTuple">
-      <HintPath>..\packages\System.ValueTuple.4.3.1\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+    <Reference Include="System.ValueTuple, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.4.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Base\" />
-    <Folder Include="Extensions\" />
-  </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
 </Project>

--- a/Sources/Spritesheet/packages.config
+++ b/Sources/Spritesheet/packages.config
@@ -4,5 +4,5 @@
   <package id="System.Collections" version="4.3.0" targetFramework="portable45-net45+win8+wpa81" />
   <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="portable45-net45+win8+wpa81" />
   <package id="System.Runtime" version="4.3.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="System.ValueTuple" version="4.3.1" targetFramework="portable45-net45+win8+wpa81" />
+  <package id="System.ValueTuple" version="4.4.0" targetFramework="portable45-net45+win8+wpa81" />
 </packages>


### PR DESCRIPTION
- Change class name Spritesheet to SpriteSheet
because class and namespace with same name
- Remove this.
- Remove did not use namespace

** i love your library but i won't use class and namespace with same name.
why i don't like ? = https://blogs.msdn.microsoft.com/ericlippert/2010/03/09/do-not-name-a-class-the-same-as-its-namespace-part-one/